### PR TITLE
Added active

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# top-most EditorConfig file
+root = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{rb}]
+charset = utf-8
+
+# 2 space indentation
+[*.{rb}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /coverage
 /Gemfile.lock
 /pkg
+.idea/

--- a/lib/probe_dock_rspec/meta_parser.rb
+++ b/lib/probe_dock_rspec/meta_parser.rb
@@ -7,13 +7,13 @@ module ProbeDockRSpec
 
       options = {}
 
-      %i(key category tags tickets data).each do |attr|
-        options[attr] = send "extract_#{attr}", example, groups
+      %i(key category tags tickets data active).each do |attr|
+        options[attr] = send("extract_#{attr}", example, groups)
       end
 
-      name_parts = extract_name_parts example, groups
-      options[:name] = name_parts.join ' '
-      options[:fingerprint] = Digest::SHA1.hexdigest name_parts.join('|||')
+      name_parts = extract_name_parts(example, groups)
+      options[:name] = name_parts.join(' ')
+      options[:fingerprint] = Digest::SHA1.hexdigest(name_parts.join('|||'))
 
       data = options[:data]
       metadata = example.metadata
@@ -29,12 +29,11 @@ module ProbeDockRSpec
 
     private
 
-    def self.extract_key example, groups = []
+    def self.extract_key(example, groups = [])
       (groups.collect{ |g| probedock_meta(g)[:key] } << probedock_meta(example)[:key]).compact.reject{ |k| k.strip.empty? }.last
     end
 
-    def self.probedock_meta holder
-
+    def self.probedock_meta(holder)
       meta = holder.metadata[:probedock] || {}
 
       if meta.kind_of? String
@@ -46,24 +45,29 @@ module ProbeDockRSpec
       end
     end
 
-    def self.extract_name_parts example, groups = []
+    def self.extract_name_parts(example, groups = [])
       (groups.collect(&:description) << example.description).compact.collect(&:strip).reject{ |p| p.empty? }
     end
 
-    def self.extract_category example, groups = []
+    def self.extract_category(example, groups = [])
       cat = (groups.collect{ |g| probedock_meta(g)[:category] } << probedock_meta(example)[:category]).compact.last
       cat ? cat.to_s : nil
     end
 
-    def self.extract_tags example, groups = []
+    def self.extract_active(example, groups = [])
+      active = (groups.collect{ |g| probedock_meta(g)[:active] } << probedock_meta(example)[:active]).compact.last
+      active.nil? ? nil : active
+    end
+
+    def self.extract_tags(example, groups = [])
       (groups.collect{ |g| wrap probedock_meta(g)[:tags] } + (wrap probedock_meta(example)[:tags])).flatten.compact.uniq.collect(&:to_s)
     end
 
-    def self.extract_tickets example, groups = []
+    def self.extract_tickets(example, groups = [])
       (groups.collect{ |g| wrap probedock_meta(g)[:tickets] } + (wrap probedock_meta(example)[:tickets])).flatten.compact.uniq.collect(&:to_s)
     end
 
-    def self.extract_data example, groups = []
+    def self.extract_data(example, groups = [])
       probedock_meta(example)[:data] || {}
     end
 

--- a/lib/probe_dock_rspec/meta_parser.rb
+++ b/lib/probe_dock_rspec/meta_parser.rb
@@ -55,8 +55,7 @@ module ProbeDockRSpec
     end
 
     def self.extract_active(example, groups = [])
-      active = (groups.collect{ |g| probedock_meta(g)[:active] } << probedock_meta(example)[:active]).compact.last
-      active.nil? ? nil : active
+      (groups.collect{ |g| probedock_meta(g)[:active] } << probedock_meta(example)[:active]).compact.last
     end
 
     def self.extract_tags(example, groups = [])

--- a/spec/meta_parser_spec.rb
+++ b/spec/meta_parser_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ProbeDockRSpec::MetaParser do
       })
     end
 
-    describe 'with categories, actives, tags and tickets' do
+    describe 'with categories, active flag, tags and tickets' do
       let(:groups_arg) do
         [
           group_double('A', category: 'unit', tags: %w(a b c), active: false),
@@ -34,25 +34,25 @@ RSpec.describe ProbeDockRSpec::MetaParser do
         ]
       end
 
-      it 'should override the category and active and combine the tags and tickets' do
+      it 'should override the category and active flag and combine the tags and tickets' do
         expect_result_options({
           name: 'A b c should work',
           fingerprint: sample_fingerprint,
           category: 'integration',
-					active: true,
+          active: true,
           tags: %w(a b c d),
           tickets: %w(t1 t2 t3 t4)
         })
       end
 
-      describe 'and a category and active, tags and tickets at the level of the test' do
+      describe 'and a category and active flag, tags and tickets at the level of the test' do
         let(:example_arg){ example_double 'should work', category: 'performance', tags: %w(a e), tickets: %w(t2 t4), active: false }
 
-        it 'should override the category and active and combine the tags and tickets' do
+        it 'should override the category and active flag and combine the tags and tickets' do
           expect_result_options({
             name: 'A b c should work',
             fingerprint: sample_fingerprint,
-						active: false,
+            active: false,
             category: 'performance',
             tags: %w(a b c d e),
             tickets: %w(t1 t2 t3 t4)
@@ -86,10 +86,10 @@ RSpec.describe ProbeDockRSpec::MetaParser do
     end
   end
 
-	describe 'with metadata containing an active' do
+	describe 'with metadata containing an active flag' do
    let(:example_arg){ example_double 'should work', active: false }
 
-   it 'should extract the active from the metadata' do
+   it 'should extract the active flag from the metadata' do
      expect_result_options({
        name: 'Something should work',
        fingerprint: sample_fingerprint,

--- a/spec/meta_parser_spec.rb
+++ b/spec/meta_parser_spec.rb
@@ -7,50 +7,52 @@ RSpec.describe ProbeDockRSpec::MetaParser do
   let(:sample_fingerprint){ '66d8e9645db2878b53b6dd51acb672e97c389c87' }
   subject{ described_class.parse example_arg, groups_arg }
 
-  it "should extract the name and fingerprint of a test with no metadata" do
+  it 'should extract the name and fingerprint of a test with no metadata' do
     expect_result_options({
       name: 'Something should work',
       fingerprint: sample_fingerprint
     })
   end
 
-  describe "with multiple groups" do
+  describe 'with multiple groups' do
     let(:groups_arg){ [ group_double('A'), group_double('b'), group_double('c') ] }
     let(:sample_fingerprint){ '1c22e0ad110dc5b07761beec69712267fc384152' }
 
-    it "should build the name and fingerprint by concatenating all group descriptions and the example description" do
+    it 'should build the name and fingerprint by concatenating all group descriptions and the example description' do
       expect_result_options({
         name: 'A b c should work',
         fingerprint: sample_fingerprint
       })
     end
 
-    describe "with categories, tags and tickets" do
+    describe 'with categories, actives, tags and tickets' do
       let(:groups_arg) do
         [
-          group_double('A', category: 'unit', tags: %w(a b c)),
+          group_double('A', category: 'unit', tags: %w(a b c), active: false),
           group_double('b', tickets: %w(t1 t3)),
-          group_double('c', category: 'integration', tags: %w(a c d), tickets: %w(t1 t2 t4))
+          group_double('c', category: 'integration', tags: %w(a c d), tickets: %w(t1 t2 t4), active: true),
         ]
       end
 
-      it "should override the category and combine the tags and tickets" do
+      it 'should override the category and active and combine the tags and tickets' do
         expect_result_options({
           name: 'A b c should work',
           fingerprint: sample_fingerprint,
           category: 'integration',
+					active: true,
           tags: %w(a b c d),
           tickets: %w(t1 t2 t3 t4)
         })
       end
 
-      describe "and a category, tags and tickets at the level of the test" do
-        let(:example_arg){ example_double 'should work', category: 'performance', tags: %w(a e), tickets: %w(t2 t4) }
+      describe 'and a category and active, tags and tickets at the level of the test' do
+        let(:example_arg){ example_double 'should work', category: 'performance', tags: %w(a e), tickets: %w(t2 t4), active: false }
 
-        it "should override the category and combine the tags and tickets" do
+        it 'should override the category and active and combine the tags and tickets' do
           expect_result_options({
             name: 'A b c should work',
             fingerprint: sample_fingerprint,
+						active: false,
             category: 'performance',
             tags: %w(a b c d e),
             tickets: %w(t1 t2 t3 t4)
@@ -60,10 +62,10 @@ RSpec.describe ProbeDockRSpec::MetaParser do
     end
   end
 
-  describe "with metadata containing a key" do
+  describe 'with metadata containing a key' do
     let(:example_arg){ example_double 'should work', key: 'abc' }
 
-    it "should extract the key from the metadata" do
+    it 'should extract the key from the metadata' do
       expect_result_options({
         key: 'abc',
         name: 'Something should work',
@@ -72,10 +74,10 @@ RSpec.describe ProbeDockRSpec::MetaParser do
     end
   end
 
-  describe "with metadata containing a category" do
+  describe 'with metadata containing a category' do
     let(:example_arg){ example_double 'should work', category: 'integration' }
 
-    it "should extract the category from the metadata" do
+    it 'should extract the category from the metadata' do
       expect_result_options({
         name: 'Something should work',
         fingerprint: sample_fingerprint,
@@ -84,10 +86,22 @@ RSpec.describe ProbeDockRSpec::MetaParser do
     end
   end
 
-  describe "with metadata containing tags" do
+	describe 'with metadata containing an active' do
+   let(:example_arg){ example_double 'should work', active: false }
+
+   it 'should extract the active from the metadata' do
+     expect_result_options({
+       name: 'Something should work',
+       fingerprint: sample_fingerprint,
+       active: false
+     })
+   end
+ end
+
+  describe 'with metadata containing tags' do
     let(:example_arg){ example_double 'should work', tags: %w(a b c) }
 
-    it "should extract the tags from the metadata" do
+    it 'should extract the tags from the metadata' do
       expect_result_options({
         name: 'Something should work',
         fingerprint: sample_fingerprint,
@@ -96,10 +110,10 @@ RSpec.describe ProbeDockRSpec::MetaParser do
     end
   end
 
-  describe "with metadata containing tickets" do
+  describe 'with metadata containing tickets' do
     let(:example_arg){ example_double 'should work', tickets: %w(t1 t2) }
 
-    it "should extract the tickets from the metadata" do
+    it 'should extract the tickets from the metadata' do
       expect_result_options({
         name: 'Something should work',
         fingerprint: sample_fingerprint,
@@ -108,10 +122,10 @@ RSpec.describe ProbeDockRSpec::MetaParser do
     end
   end
 
-  describe "with metadata containing custom data" do
+  describe 'with metadata containing custom data' do
     let(:example_arg){ example_double 'should work', data: { foo: 'bar', baz: 'qux' } }
 
-    it "should extract the tickets from the metadata" do
+    it 'should extract the tickets from the metadata' do
       expect_result_options({
         name: 'Something should work',
         fingerprint: sample_fingerprint,
@@ -123,10 +137,10 @@ RSpec.describe ProbeDockRSpec::MetaParser do
     end
   end
 
-  describe "with string metadata" do
+  describe 'with string metadata' do
     let(:example_arg){ example_double 'should work', 'abc' }
 
-    it "should use the metadata as key" do
+    it 'should use the metadata as key' do
       expect_result_options({
         key: 'abc',
         name: 'Something should work',
@@ -135,10 +149,10 @@ RSpec.describe ProbeDockRSpec::MetaParser do
     end
   end
 
-  describe "with unexpected metadata" do
+  describe 'with unexpected metadata' do
     let(:example_arg){ example_double 'should work', 42 }
 
-    it "should extract the name and fingerprint of the test" do
+    it 'should extract the name and fingerprint of the test' do
       expect_result_options({
         name: 'Something should work',
         fingerprint: sample_fingerprint
@@ -146,19 +160,20 @@ RSpec.describe ProbeDockRSpec::MetaParser do
     end
   end
 
-  def example_double desc, metadata = {}
+  def example_double(desc, metadata = {})
     double description: desc, metadata: { probedock: metadata }
   end
 
-  def group_double desc, metadata = {}
+  def group_double(desc, metadata = {})
     double description: desc, metadata: { probedock: metadata }
   end
 
-  def expect_result_options options = {}
+  def expect_result_options(options = {})
 
     result_options = {
       key: nil,
       category: nil,
+      active: nil,
       tags: [],
       tickets: [],
       data: {}


### PR DESCRIPTION
With the latest `probedock-ruby:0.1.5`, the annotation through test names are supported out of the box.
